### PR TITLE
Updated README & added requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,23 +77,24 @@ The Gap framework is supported on Windows, MacOS, and Linux. It has been package
 
   1. install [miniconda](https://conda.io/miniconda.html)
 
-  2. (optional)  
-      + Create an environment with: `conda create -n gap python==3.7 jupyter`  
+  2. install conda virtual environment and required packages
+      + Create an environment with: `conda create -n gap python==3.7 jupyter pip`  
       + Activate: `source activate gap`
-      + Deactivate: `source deactivate`
-
-  3. install GapML:  
       + `pip install gapml`
 
-      Dependecies if you are on **Linux** or **Mac**:  
+      Dependencies for **Linux** or **Mac**:  
       + Tesseract:    `conda install -c conda-forge tesseract`  
       + Ghostscript:  `conda install -c conda-forge ghostscript`  
       + Imagemagick:  `conda install -c conda-forge imagemagick`
 
-      for **Windows** get the executables in the following links:  
+      Dependencies for **Windows** executables in the following links:  
       + Ghostscript:  https://www.ghostscript.com/download/gsdnld.html  
       + Imagemagick:  https://www.imagemagick.org/script/download.php  
       + Tesseract:    https://github.com/UB-Mannheim/tesseract/wiki
+
+  3. exiting conda virtual environment:
+      + Windows: `deactivate`
+      + Linux/macOS: `source deactivate`
 
 ## Setup.py Installation:
 
@@ -196,6 +197,10 @@ The following are the pre-built automated unit tests, which are located under th
     image_test.py       # Tests the Image and Images Class in the Vision Module
 
 The automated tests are executed as follows:
+  
+  1. From directory root enter `cd tests`
+
+  2. Tests can be run by:
 
     pytest -v document_test.py
     pytest -v page_test.py
@@ -209,7 +214,9 @@ Information on the percent of code that is covered (and what source lines not co
 
     pip install pytest-cov
 
-Testing with code coverage is executed as follows:
+  1. From directory root enter `cd tests`
+
+  2. To run tests with coverage: 
 
     pytest --cov=gapml.splitter document_test.py page_test.py
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+beautifulsoup4==4.6.3
+numpy==1.14.5
+h5py==2.8.0
+imutils==0.5.1
+Unidecode==1.0.22
+nltk==3.3
+pandas==0.23.4
+requests==2.19.1
+opencv-python==3.4.3.18
+Pillow==5.2.0
+matplotlib==2.2.3

--- a/setup.py
+++ b/setup.py
@@ -5,24 +5,14 @@ Autor: David Molina @virtualdvid
 
 from setuptools import setup, find_packages
 
-#setup components
-with open('README.md', 'r', encoding="utf-8") as f:
-    long_description = f.read()
+try: # for pip >= 10
+        from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+        from pip.req import parse_requirements
 
-install_requires=[
-    'bs4',
-    'numpy',
-    'h5py',
-    'imutils',
-    'unidecode',
-    'nltk',
-    'pandas',
-    'requests',
-    'opencv-python',
-    'pillow',
-    'matplotlib'
-    ]
-		  
+install_reqs = parse_requirements(
+    'requirements/requirements.txt', session='hack')
+
 tests_require=[
     'pytest',
     'pytest-cov']
@@ -59,9 +49,9 @@ setup(
     license='Apache 2.0',
     url='https://github.com/andrewferlitsch/Gap',
     project_urls=project_urls,
-    long_description=long_description,
+    long_description=open('README.md').read()
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
-    install_requires=install_requires,
+    install_requires=[str(ir.req) for ir in install_reqs],
     tests_require=tests_require,
     package_data=package_data,
     classifiers=classifiers


### PR DESCRIPTION
README updated to mention to enter the tests dir before running tests.

This change has been on my mind for a bit. 
Included requirements.txt
Setup.py updated to read from requirements.txt

Reasoning:
Within the original setup.py the requirements where hard coded and did not have specific versions to download for each requirement.  This is also standard procedure for python packaging.  Having greater control on what version of the requirement is good in case future requirement releases incorporate functionality that may not be addressed in the current gapml release.